### PR TITLE
fix fetchPhotoList bug

### DIFF
--- a/src/Album.js
+++ b/src/Album.js
@@ -84,7 +84,7 @@ class GPhotosAlbum {
         });
 
     const photoList = results[1].map((info) => {
-      const data = Object.assign(Photo.parseInfo(info), { _parent: this });
+      const data = Object.assign(Photo.parseInfo(info), { _parent: this._gphotos });
       return new Photo(data);
     });
 


### PR DESCRIPTION
GPhotosAlbumのfetchPhotoListを使った場合、
GPhotosPhotoの`_gphotos`に間違ったオブジェクトが入っていたため修正